### PR TITLE
Fix #9 - Relax _MSC_VER requirements due to MSVC recently releasing cl 1940

### DIFF
--- a/recipes/ruby/all/conandata.yml
+++ b/recipes/ruby/all/conandata.yml
@@ -38,6 +38,9 @@ patches:
       patch_description: "Replace dmyext / dmyenc (no-op) with the extinit.c encinit.c"
       patch_type: "portability"
       patch_source: "cf https://bugs.ruby-lang.org/issues/19758"
+    - patch_file: "patches/0010-fixup-msc-ver-1940-3.3.0.patch"
+      patch_description: "Patch MSC_VER for MSVC 17.10.2 (_MSC_VER is 1940)"
+      patch_type: "portability"
   "3.2.2":
     - patch_file: "patches/0001-darwin-includedir-3.2.2.patch"
       patch_description: "Remove SDKROOT on macOS"
@@ -67,6 +70,9 @@ patches:
       patch_description: "Replace dmyext / dmyenc (no-op) with the extinit.c encinit.c"
       patch_type: "portability"
       patch_source: "cf https://bugs.ruby-lang.org/issues/19758"
+    - patch_file: "patches/0010-fixup-msc-ver-1940-3.2.2.patch"
+      patch_description: "Patch MSC_VER for MSVC 17.10.2 (_MSC_VER is 1940)"
+      patch_type: "portability"
   "3.1.0":
     - patch_file: "patches/0001-darwin-includedir-3.1.0.patch"
       patch_description: "Remove SDKROOT on macOS"
@@ -97,4 +103,7 @@ patches:
       patch_type: "backport"
     - patch_file: "patches/0010-fixup-libruby-static-3.1.0.patch"
       patch_description: "Replace dmyext / dmyenc (no-op) with the extinit.c encinit.c"
+      patch_type: "portability"
+    - patch_file: "patches/0010-fixup-msc-ver-1940-3.1.0.patch"
+      patch_description: "Patch MSC_VER for MSVC 17.10.2 (_MSC_VER is 1940)"
       patch_type: "portability"

--- a/recipes/ruby/all/patches/0010-fixup-msc-ver-1940-3.1.0.patch
+++ b/recipes/ruby/all/patches/0010-fixup-msc-ver-1940-3.1.0.patch
@@ -1,0 +1,17 @@
+Subject: Patch MSC_VER for MSVC 17.10.2 (_MSC_VER is 1940)
+
+diff --git win32/setup.mak win32/setup.mak
+--- win32/setup.mak
++++ win32/setup.mak
+@@ -157,7 +157,10 @@ echo TEENY = RUBY_VERSION_TEENY
+ echo RUBY_DEVEL = yes
+ #endif
+ set /a MSC_VER = _MSC_VER
+-#if _MSC_VER > 1900
++#if _MSC_VER >= 1920
++set /a MSC_VER_LOWER = 1920
++set /a MSC_VER_UPPER = 1959
++#elif _MSC_VER >= 1900
+ set /a MSC_VER_LOWER = MSC_VER/10*10+0
+ set /a MSC_VER_UPPER = MSC_VER/10*10+9
+ #endif

--- a/recipes/ruby/all/patches/0010-fixup-msc-ver-1940-3.2.2.patch
+++ b/recipes/ruby/all/patches/0010-fixup-msc-ver-1940-3.2.2.patch
@@ -1,0 +1,16 @@
+Subject: Patch MSC_VER for MSVC 17.10.2 (_MSC_VER is 1940)
+
+diff --git win32/setup.mak win32/setup.mak
+--- win32/setup.mak
++++ win32/setup.mak
+@@ -197,8 +197,8 @@ echo ABI_VERSION = RUBY_ABI_VERSION
+ #endif
+ set /a MSC_VER = _MSC_VER
+ #if _MSC_VER >= 1920
+-set /a MSC_VER_LOWER = MSC_VER/20*20+0
+-set /a MSC_VER_UPPER = MSC_VER/20*20+19
++set /a MSC_VER_LOWER = 1920
++set /a MSC_VER_UPPER = 1959
+ #elif _MSC_VER >= 1900
+ set /a MSC_VER_LOWER = MSC_VER/10*10+0
+ set /a MSC_VER_UPPER = MSC_VER/10*10+9

--- a/recipes/ruby/all/patches/0010-fixup-msc-ver-1940-3.3.0.patch
+++ b/recipes/ruby/all/patches/0010-fixup-msc-ver-1940-3.3.0.patch
@@ -1,0 +1,16 @@
+Subject: Patch MSC_VER for MSVC 17.10.2 (_MSC_VER is 1940)
+
+diff --git win32/setup.mak win32/setup.mak
+--- win32/setup.mak
++++ win32/setup.mak
+@@ -198,8 +198,8 @@ echo ABI_VERSION = RUBY_ABI_VERSION
+ #endif
+ set /a MSC_VER = _MSC_VER
+ #if _MSC_VER >= 1920
+-set /a MSC_VER_LOWER = MSC_VER/20*20+0
+-set /a MSC_VER_UPPER = MSC_VER/20*20+19
++set /a MSC_VER_LOWER = 1920
++set /a MSC_VER_UPPER = 1959
+ #elif _MSC_VER >= 1900
+ set /a MSC_VER_LOWER = MSC_VER/10*10+0
+ set /a MSC_VER_UPPER = MSC_VER/10*10+9


### PR DESCRIPTION
```
$ cl /?
Microsoft (R) C/C++ Optimizing Compiler Version 19.40.33811 for x64
```