### PR TITLE
Remove outdated runners and add new ones + ubuntu armv8 gcc-11 & 13

### DIFF
--- a/.github/workflows/conan_v2.yml
+++ b/.github/workflows/conan_v2.yml
@@ -26,7 +26,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-14-armv8, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
         build_type: [Release, Debug]
         recipe_version: ["3.2.2", "3.3.0"]
         include:
@@ -85,13 +85,6 @@ jobs:
           os: macos-13
           arch: x86_64
           SDKROOT: /Applications/Xcode_15.2.app
-          allow_failure: false
-        - build_name: apple-clang-14-armv8
-          compiler: apple-clang
-          version: 14
-          os: macos-14
-          arch: armv8
-          SDKROOT: /Applications/Xcode_14.3.1.app
           allow_failure: false
         - build_name: apple-clang-15-armv8
           compiler: apple-clang

--- a/.github/workflows/conan_v2.yml
+++ b/.github/workflows/conan_v2.yml
@@ -26,16 +26,10 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
         build_type: [Release, Debug]
         recipe_version: ["3.2.2", "3.3.0"]
         include:
-        - build_name: gcc-10
-          compiler: gcc
-          version: 10
-          os: ubuntu-22.04
-          arch: x86_64
-          allow_failure: false
         - build_name: gcc-11
           compiler: gcc
           version: 11

--- a/.github/workflows/conan_v2.yml
+++ b/.github/workflows/conan_v2.yml
@@ -26,7 +26,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-16, apple-clang-17, apple-clang-15-armv8, apple-clang-16-armv8, apple-clang-17-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-16, apple-clang-17, apple-clang-15-armv8, apple-clang-16-armv8, apple-clang-17-armv8, msvc-2022]
         build_type: [Release, Debug]
         recipe_version: ["3.2.2", "3.3.0"]
         include:
@@ -114,12 +114,6 @@ jobs:
           os: macos-15
           arch: armv8
           SDKROOT: /Applications/Xcode_16.4.app
-          allow_failure: false
-        - build_name: msvc-2019
-          compiler: msvc
-          version: 192
-          os: windows-2019
-          arch: x86_64
           allow_failure: false
         - build_name: msvc-2022
           compiler: msvc

--- a/.github/workflows/conan_v2.yml
+++ b/.github/workflows/conan_v2.yml
@@ -26,65 +26,51 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, apple-clang-11, apple-clang-12, apple-clang-13, apple-clang-14, apple-clang-15, apple-clang-14-armv8, apple-clang-15-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-14-armv8, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
         build_type: [Release, Debug]
-        recipe_version: ["3.1.0", "3.2.2", "3.3.0"]
+        recipe_version: ["3.2.2", "3.3.0"]
         include:
-        - build_name: gcc-9
-          compiler: gcc
-          version: 9
-          os: ubuntu-20.04
-          arch: x86_64
-          allow_failure: false
-          # dockerImage: conanio/gcc9-ubuntu16.04:latest
         - build_name: gcc-10
           compiler: gcc
           version: 10
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           allow_failure: false
-          # dockerImage: conanio/gcc10-ubuntu16.04:latest
         - build_name: gcc-11
           compiler: gcc
           version: 11
           os: ubuntu-22.04
           arch: x86_64
           allow_failure: false
-          # dockerImage: conanio/gcc11-ubuntu16.04:latest
         - build_name: gcc-12
           compiler: gcc
           version: 12
           os: ubuntu-22.04
           arch: x86_64
           allow_failure: false
-          # dockerImage: conanio/gcc12-ubuntu16.04:latest
         - build_name: gcc-13
           compiler: gcc
           version: 13
           os: ubuntu-22.04
           arch: x86_64
           allow_failure: false
-          # dockerImage: conanio/gcc13-ubuntu16.04:latest
-        - build_name: apple-clang-11
-          compiler: apple-clang
+        - build_name: gcc-14
+          compiler: gcc
+          version: 14
+          os: ubuntu-24.04
+          arch: x86_64
+          allow_failure: false
+        - build_name: gcc-11-armv8
+          compiler: gcc
           version: 11
-          os: macos-11
-          arch: x86_64
-          SDKROOT: /Applications/Xcode_11.7.app
+          os: ubuntu-22.04-arm
+          arch: armv8
           allow_failure: false
-        - build_name: apple-clang-12
-          compiler: apple-clang
-          version: 12
-          os: macos-11
-          arch: x86_64
-          SDKROOT: /Applications/Xcode_12.4.app
-          allow_failure: false
-        - build_name: apple-clang-13
-          compiler: apple-clang
+        - build_name: gcc-13-armv8
+          compiler: gcc
           version: 13
-          os: macos-12
-          arch: x86_64
-          SDKROOT: /Applications/Xcode_13.2.1.app
+          os: ubuntu-24.04-arm
+          arch: armv8
           allow_failure: false
         - build_name: apple-clang-14
           compiler: apple-clang
@@ -92,7 +78,6 @@ jobs:
           os: macos-13
           arch: x86_64
           SDKROOT: /Applications/Xcode_14.3.1.app
-          # macos-12  /Applications/Xcode_14.2.app
           allow_failure: false
         - build_name: apple-clang-15
           compiler: apple-clang
@@ -114,6 +99,13 @@ jobs:
           os: macos-14
           arch: armv8
           SDKROOT: /Applications/Xcode_15.2.app
+          allow_failure: false
+        - build_name: apple-clang-16-armv8
+          compiler: apple-clang
+          version: 16
+          os: macos-14
+          arch: armv8
+          SDKROOT: /Applications/Xcode_16.2.app
           allow_failure: false
         - build_name: msvc-2019
           compiler: msvc
@@ -282,6 +274,8 @@ jobs:
       shell: bash
       working-directory: recipes/ruby/all
       run: |
+        # bzip2 won't build from source if you end up trying with cmake > 4.0
+        export CMAKE_POLICY_VERSION_MINIMUM=3.5
         conan_command="-s:a compiler.cppstd=20 --version ${{ matrix.recipe_version }} -o '*/*:shared=False' -s:a build_type=${{ matrix.build_type }} --build missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True ."
         echo "conan_command=$conan_command"
         set +e

--- a/.github/workflows/conan_v2.yml
+++ b/.github/workflows/conan_v2.yml
@@ -26,7 +26,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-16, apple-clang-17, apple-clang-15-armv8, apple-clang-16-armv8, apple-clang-17-armv8, msvc-2019, msvc-2022]
         build_type: [Release, Debug]
         recipe_version: ["3.2.2", "3.3.0"]
         include:
@@ -71,7 +71,7 @@ jobs:
           version: 14
           os: macos-13
           arch: x86_64
-          SDKROOT: /Applications/Xcode_14.3.1.app
+          SDKROOT: /Applications/Xcode_14.3.app
           allow_failure: false
         - build_name: apple-clang-15
           compiler: apple-clang
@@ -80,19 +80,40 @@ jobs:
           arch: x86_64
           SDKROOT: /Applications/Xcode_15.2.app
           allow_failure: false
+        - build_name: apple-clang-16
+          compiler: apple-clang
+          version: 16
+          os: macos-15-intel
+          arch: x86_64
+          SDKROOT: /Applications/Xcode_16.2.app
+          allow_failure: false
+        - build_name: apple-clang-17
+          compiler: apple-clang
+          version: 17
+          os: macos-15-intel
+          arch: x86_64
+          SDKROOT: /Applications/Xcode_16.4.app
+          allow_failure: false
         - build_name: apple-clang-15-armv8
           compiler: apple-clang
           version: 15
           os: macos-14
           arch: armv8
-          SDKROOT: /Applications/Xcode_15.2.app
+          SDKROOT: /Applications/Xcode_15.4.app
           allow_failure: false
         - build_name: apple-clang-16-armv8
           compiler: apple-clang
           version: 16
-          os: macos-14
+          os: macos-15
           arch: armv8
           SDKROOT: /Applications/Xcode_16.2.app
+          allow_failure: false
+        - build_name: apple-clang-17-armv8
+          compiler: apple-clang
+          version: 16
+          os: macos-15
+          arch: armv8
+          SDKROOT: /Applications/Xcode_16.4.app
           allow_failure: false
         - build_name: msvc-2019
           compiler: msvc

--- a/.github/workflows/test_clang.yml
+++ b/.github/workflows/test_clang.yml
@@ -1,0 +1,93 @@
+name: Test Clang
+
+on:
+  push:
+    branches: [ main, bump_runners ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  VERIFY_SSL: true
+
+jobs:
+  build:
+
+    name: "${{ matrix.os }} (${{ matrix.arch }})"
+
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
+      fail-fast: false
+      matrix:
+        os: [macos-13, macos-15-intel, macos-14, macos-15, macos-26]
+        include:
+        - os: macos-13
+          arch: x86_64
+        - os: macos-15-intel
+          arch: x86_64
+        - os: macos-14
+          arch: armv8
+        - os: macos-15
+          arch: armv8
+        - os: macos-26
+          arch: armv8
+
+
+    steps:
+    - name: Show Xcode versions
+      shell: bash
+      run: |
+        set -x
+
+        begin_group() { echo -e "::group::\033[93m$1\033[0m"; }
+
+        begin_group "Default"
+        xcrun --sdk macosx --show-sdk-path
+        clang --version
+        which clang
+        echo "::endgroup::"
+
+        for xcode in $(find /Applications -name "Xcode_*.app" -type d -maxdepth 1); do
+          begin_group "$xcode"
+          sudo xcode-select -switch $xcode
+          clang --version
+          which clang
+          echo "::endgroup::"
+        done
+
+        pip install markdown
+
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
+
+    - name: produce a table
+      shell: python
+      run: |
+        import os
+        from pathlib import Path
+        import subprocess
+
+        def get_clang_version():
+            result = subprocess.check_output(['clang', '--version'], text=True)
+            return result.splitlines()[0]
+
+        def get_xcode_version():
+            result = subprocess.check_output(['xcodebuild', '-version'], text=True)
+            return result.splitlines()[0].split(' ')[-1]
+
+        def print_and_append_to_github_step_summary(line):
+            print(line)
+            summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+            if not summary_path:
+                return
+            with Path(summary_path).open("a", encoding="utf-8") as f:
+                f.write(line + "\n")
+
+        xcode_paths = sorted(Path('/Applications').glob('Xcode_*.app'))
+        print_and_append_to_github_step_summary("| Runner | arch | Xcode Version | Build | Clang Version |")
+        print_and_append_to_github_step_summary("|--------|------|---------------|-------|---------------|")
+        for xcode_path in xcode_paths:
+            subprocess.check_call(['sudo', 'xcode-select', '-switch', str(xcode_path)])
+            clang_version = get_clang_version()
+            print_and_append_to_github_step_summary(f"| ${{ matrix.os }} | ${{ matrix.arch }} | {xcode_path.stem} | {get_xcode_version()} | {get_clang_version()} |")

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -25,7 +25,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
+        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-16, apple-clang-17, apple-clang-15-armv8, apple-clang-16-armv8, apple-clang-17-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
         build_type: [Release, Debug]
         # Right now, conan-center uses gcc-11 (and apple-clang 13, but that shoudln't be a problem) which is at risk of causing ABI compatibiliy issues (GLIBC/GLIBCXX version mistmatches)
         include:
@@ -76,7 +76,7 @@ jobs:
           version: 14
           os: macos-13
           arch: x86_64
-          SDKROOT: /Applications/Xcode_14.3.1.app
+          SDKROOT: /Applications/Xcode_14.3.app
           allow_failure: false
           build_strategy: 'missing'
         - build_name: apple-clang-15
@@ -87,20 +87,44 @@ jobs:
           SDKROOT: /Applications/Xcode_15.2.app
           allow_failure: false
           build_strategy: 'missing'
+        - build_name: apple-clang-16
+          compiler: apple-clang
+          version: 16
+          os: macos-15-intel
+          arch: x86_64
+          SDKROOT: /Applications/Xcode_16.2.app
+          allow_failure: false
+          build_strategy: 'missing'
+        - build_name: apple-clang-17
+          compiler: apple-clang
+          version: 17
+          os: macos-15-intel
+          arch: x86_64
+          SDKROOT: /Applications/Xcode_16.4.app
+          allow_failure: false
+          build_strategy: 'missing'
         - build_name: apple-clang-15-armv8
           compiler: apple-clang
           version: 15
           os: macos-14
           arch: armv8
-          SDKROOT: /Applications/Xcode_15.2.app
+          SDKROOT: /Applications/Xcode_15.4.app
           allow_failure: false
           build_strategy: 'missing'
         - build_name: apple-clang-16-armv8
           compiler: apple-clang
           version: 16
-          os: macos-14
+          os: macos-15
           arch: armv8
           SDKROOT: /Applications/Xcode_16.2.app
+          allow_failure: false
+          build_strategy: 'missing'
+        - build_name: apple-clang-17-armv8
+          compiler: apple-clang
+          version: 17
+          os: macos-15
+          arch: armv8
+          SDKROOT: /Applications/Xcode_16.4.app
           allow_failure: false
           build_strategy: 'missing'
         - build_name: msvc-2019

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -25,18 +25,10 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
+        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
         build_type: [Release, Debug]
         # Right now, conan-center uses gcc-11 (and apple-clang 13, but that shoudln't be a problem) which is at risk of causing ABI compatibiliy issues (GLIBC/GLIBCXX version mistmatches)
-        # So we set it to build all for gcc-9 and gcc-10
         include:
-        - build_name: gcc-10
-          compiler: gcc
-          version: 10
-          os: ubuntu-22.04
-          arch: x86_64
-          allow_failure: false
-          build_strategy: '*'
         - build_name: gcc-11
           compiler: gcc
           version: 11

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -25,7 +25,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
         build_type: [Release, Debug]
         # Right now, conan-center uses gcc-11 (and apple-clang 13, but that shoudln't be a problem) which is at risk of causing ABI compatibiliy issues (GLIBC/GLIBCXX version mistmatches)
         # So we set it to build all for gcc-9 and gcc-10

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -25,7 +25,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-16, apple-clang-17, apple-clang-15-armv8, apple-clang-16-armv8, apple-clang-17-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
+        build_name: [gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-16, apple-clang-17, apple-clang-15-armv8, apple-clang-16-armv8, apple-clang-17-armv8, msvc-2022, msvc-2022-i386]
         build_type: [Release, Debug]
         # Right now, conan-center uses gcc-11 (and apple-clang 13, but that shoudln't be a problem) which is at risk of causing ABI compatibiliy issues (GLIBC/GLIBCXX version mistmatches)
         include:
@@ -125,13 +125,6 @@ jobs:
           os: macos-15
           arch: armv8
           SDKROOT: /Applications/Xcode_16.4.app
-          allow_failure: false
-          build_strategy: 'missing'
-        - build_name: msvc-2019
-          compiler: msvc
-          version: 192
-          os: windows-2019
-          arch: x86_64
           allow_failure: false
           build_strategy: 'missing'
         - build_name: msvc-2022

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -294,7 +294,8 @@ jobs:
         set +e
         if [ "$RUNNER_OS" == "macOS" ]; then
           # Avoid "builtin __has_nothrow_assign is deprecated; use __is_nothrow_assignable instead" in boost/1.79 with recent clang
-          conan_command+=(-c tools.build:cxxflags="['-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']")
+          # Avoid ./boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for the enumeration type 'int_float_mixture_enum' [-Wenum-constexpr-conversion]
+          conan_command+=(-c tools.build:cxxflags="['-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION', '-Wno-enum-constexpr-conversion']")
         fi
         if [ "${{ matrix.build_name }}" == "msvc-2022-i386" ]; then
           conan_command+=(-o with_testing=False -o with_benchmark=False -o with_ruby=False -o with_python=False -o with_csharp=True)

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -25,7 +25,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-14-armv8, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
+        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
         build_type: [Release, Debug]
         # Right now, conan-center uses gcc-11 (and apple-clang 13, but that shoudln't be a problem) which is at risk of causing ABI compatibiliy issues (GLIBC/GLIBCXX version mistmatches)
         # So we set it to build all for gcc-9 and gcc-10
@@ -93,14 +93,6 @@ jobs:
           os: macos-13
           arch: x86_64
           SDKROOT: /Applications/Xcode_15.2.app
-          allow_failure: false
-          build_strategy: 'missing'
-        - build_name: apple-clang-14-armv8
-          compiler: apple-clang
-          version: 14
-          os: macos-14
-          arch: armv8
-          SDKROOT: /Applications/Xcode_14.3.1.app
           allow_failure: false
           build_strategy: 'missing'
         - build_name: apple-clang-15-armv8

--- a/.github/workflows/upload_deps.yml
+++ b/.github/workflows/upload_deps.yml
@@ -25,27 +25,18 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, apple-clang-11, apple-clang-12, apple-clang-13, apple-clang-14, apple-clang-15, apple-clang-14-armv8, apple-clang-15-armv8, msvc-2019, msvc-2022, msvc-2022-i386]
+        build_name: [gcc-10, gcc-11, gcc-12, gcc-13, gcc-14, gcc-11-armv8, gcc-13-armv8, apple-clang-14, apple-clang-15, apple-clang-14-armv8, apple-clang-15-armv8, apple-clang-16-armv8, msvc-2019, msvc-2022]
         build_type: [Release, Debug]
         # Right now, conan-center uses gcc-11 (and apple-clang 13, but that shoudln't be a problem) which is at risk of causing ABI compatibiliy issues (GLIBC/GLIBCXX version mistmatches)
         # So we set it to build all for gcc-9 and gcc-10
         include:
-        - build_name: gcc-9
-          compiler: gcc
-          version: 9
-          os: ubuntu-20.04
-          arch: x86_64
-          allow_failure: false
-          build_strategy: '*'
-          # dockerImage: conanio/gcc9-ubuntu16.04:latest
         - build_name: gcc-10
           compiler: gcc
           version: 10
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           allow_failure: false
           build_strategy: '*'
-          # dockerImage: conanio/gcc10-ubuntu16.04:latest
         - build_name: gcc-11
           compiler: gcc
           version: 11
@@ -53,7 +44,6 @@ jobs:
           arch: x86_64
           allow_failure: false
           build_strategy: 'missing'
-          # dockerImage: conanio/gcc11-ubuntu16.04:latest
         - build_name: gcc-12
           compiler: gcc
           version: 12
@@ -61,7 +51,6 @@ jobs:
           arch: x86_64
           allow_failure: false
           build_strategy: 'missing'
-          # dockerImage: conanio/gcc12-ubuntu16.04:latest
         - build_name: gcc-13
           compiler: gcc
           version: 13
@@ -69,29 +58,25 @@ jobs:
           arch: x86_64
           allow_failure: false
           build_strategy: 'missing'
-          # dockerImage: conanio/gcc13-ubuntu16.04:latest
-        - build_name: apple-clang-11
-          compiler: apple-clang
+        - build_name: gcc-14
+          compiler: gcc
+          version: 14
+          os: ubuntu-24.04
+          arch: x86_64
+          allow_failure: false
+          build_strategy: 'missing'
+        - build_name: gcc-11-armv8
+          compiler: gcc
           version: 11
-          os: macos-11
-          arch: x86_64
-          SDKROOT: /Applications/Xcode_11.7.app
+          os: ubuntu-22.04-arm
+          arch: armv8
           allow_failure: false
           build_strategy: 'missing'
-        - build_name: apple-clang-12
-          compiler: apple-clang
-          version: 12
-          os: macos-11
-          arch: x86_64
-          SDKROOT: /Applications/Xcode_12.4.app
-          allow_failure: false
-          build_strategy: 'missing'
-        - build_name: apple-clang-13
-          compiler: apple-clang
+        - build_name: gcc-13-armv8
+          compiler: gcc
           version: 13
-          os: macos-12
-          arch: x86_64
-          SDKROOT: /Applications/Xcode_13.2.1.app
+          os: ubuntu-24.04-arm
+          arch: armv8
           allow_failure: false
           build_strategy: 'missing'
         - build_name: apple-clang-14
@@ -100,7 +85,6 @@ jobs:
           os: macos-13
           arch: x86_64
           SDKROOT: /Applications/Xcode_14.3.1.app
-          # macos-12  /Applications/Xcode_14.2.app
           allow_failure: false
           build_strategy: 'missing'
         - build_name: apple-clang-15
@@ -125,6 +109,14 @@ jobs:
           os: macos-14
           arch: armv8
           SDKROOT: /Applications/Xcode_15.2.app
+          allow_failure: false
+          build_strategy: 'missing'
+        - build_name: apple-clang-16-armv8
+          compiler: apple-clang
+          version: 16
+          os: macos-14
+          arch: armv8
+          SDKROOT: /Applications/Xcode_16.2.app
           allow_failure: false
           build_strategy: 'missing'
         - build_name: msvc-2019
@@ -300,6 +292,8 @@ jobs:
     - name: build ${{ matrix.arch }}
       shell: bash
       run: |
+        # bzip2 won't build from source if you end up trying with cmake > 4.0
+        export CMAKE_POLICY_VERSION_MINIMUM=3.5
         aria2c https://raw.githubusercontent.com/NREL/OpenStudio/${{ github.event.inputs.branch_name}}/conanfile.py
         aria2c https://raw.githubusercontent.com/NREL/OpenStudio/${{ github.event.inputs.branch_name}}/conan.lock
 


### PR DESCRIPTION
Refactors the CI build matrix by removing outdated configurations and adding new ones.

Removes gcc-9, apple-clang-11, apple-clang-12, and apple-clang-13 builds. Adds gcc-14, gcc-11-armv8, gcc-13-armv8 and apple-clang-16-armv8 builds. Updates the Ubuntu version for gcc-10 builds to 22.04 since 20.04 was removed

Adds a CMAKE_POLICY_VERSION_MINIMUM environment variable to fix issues when building bzip2 from source with cmake > 4.0

Remove Apple Clang 14 on armv8, as macos-14 runner removed XCode_14 https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode


@anchapin @tijcolem just making you aware I'm doing this